### PR TITLE
Remove leave traphouse option in interaction coord

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -136,12 +136,6 @@ local function RegisterTraphouseInteractionTarget(traphouseID, traphouseData)
         if IsHouseOwner then
             options[#options+1] = {
                 type = "client",
-                event = "qb-traphouse:client:target:ExitTraphouse",
-                label = Lang:t("targetInfo.leave"),
-                traphouseData = traphouseData
-            }
-            options[#options+1] = {
-                type = "client",
                 event = "qb-traphouse:client:target:SeePinCode",
                 label = Lang:t("targetInfo.pin_code_see"),
                 traphouseData = traphouseData


### PR DESCRIPTION
I don't think it is designed this way, should only leave by door (exit coord)