### PR TITLE
fix(client): Fix traphouse inventory not getting focus

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -411,7 +411,7 @@ RegisterNetEvent('qb-traphouse:client:target:ViewInventory', function (data)
     TraphouseInventory.label = "traphouse_"..CurrentTraphouse
     TraphouseInventory.items = data.traphouseData.inventory
     TraphouseInventory.slots = 2
-    TriggerServerEvent("inventory:server:OpenInventory", "traphouse", CurrentTraphouse, TraphouseInventory)
+    TriggerServerEvent("inventory:server:OpenInventory", "traphouse", TraphouseInventory.label, TraphouseInventory)
 end)
 
 RegisterNetEvent('qb-traphouse:client:target:TakeOver', function ()


### PR DESCRIPTION
**Describe Pull request**
When opening the traphouse inventory, the user was not getting NUI focus on the inventory. This was caused by the wrong inventory being passed to teh openinventory event. This PR addresses that.

Fixes #42 

To test:
- Enable target
- Enter traphouse
- Takeover traphouse
- Open traphouse inventory

Before, user would not get mouse enabled with NUI focus. After this PR, user gets correct NUI focus.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
