### PR TITLE
fix(client): Add missing minZ and maxZ for target zones

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -115,7 +115,7 @@ local function RegisterTraphouseInteractionTarget(traphouseID, traphouseData)
     local coords = traphouseData.coords['interaction']
     local boxName = 'traphouseInteraction' .. traphouseID
     local boxData = traphouseData.polyzoneBoxData['interaction']
-    
+
     local options = {
         {
             type = "client",
@@ -152,6 +152,8 @@ local function RegisterTraphouseInteractionTarget(traphouseID, traphouseData)
         name = boxName,
         heading = boxData.heading,
         debugPoly = boxData.debug,
+        minZ = coords.z - 1.0,
+        maxZ = coords.z + 1.0,
     }, {
         options = options,
         distance = boxData.distance
@@ -193,6 +195,8 @@ local function RegisterTraphouseExitTarget(coords, traphouseID, traphouseData)
         name = boxName,
         heading = boxData.heading,
         debugPoly = boxData.debug,
+        minZ = coords.z - 1.0,
+        maxZ = coords.z + 1.0,
     }, {
         options = {
             {


### PR DESCRIPTION
**Describe Pull request**
This PR adds missing `minZ` and `maxZ` parameters for the qb-target box zones.

 Closes #46 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
